### PR TITLE
Fix minting when drift is zero

### DIFF
--- a/frontend/app/src/components/OvenActions/MintOrBurn.tsx
+++ b/frontend/app/src/components/OvenActions/MintOrBurn.tsx
@@ -50,7 +50,12 @@ export const MintOrBurn: React.FC<MintOrBurnProps> = ({ type }) => {
       .min(0.000001)
       .test({
         test: (value) => {
-          if (value && drift && currentTarget && type === 'mint') {
+          if (
+            value !== undefined &&
+            drift !== undefined &&
+            currentTarget !== undefined &&
+            type === 'mint'
+          ) {
             const newOutstanding = Number(ctez_outstanding) + value * 1e6;
             const tez = Number(tez_balance);
             const result = isMonthFromLiquidation(newOutstanding, currentTarget, tez, drift);


### PR DESCRIPTION
# Problem

The check to make sure `value`, `drift`, and `currentTarget` are not `undefined` is accidentally also checking that they are not zero. This makes it impossible to mint after creating a new oven, because the drift will be zero (because no baking has happened yet), so the check always fails. 

# Solution

Explicitly check for undefinedness